### PR TITLE
Allow listen to pub/sub

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -348,8 +348,9 @@ NetworkManager::create_receiver(std::string const& connection_or_topic)
   if (m_receiver_plugins.count(connection_or_topic))
     return;
 
-  auto plugin_type = ipm::get_recommended_plugin_name(is_topic(connection_or_topic) ? ipm::IpmPluginType::Subscriber
-                                                                                    : ipm::IpmPluginType::Receiver);
+  auto plugin_type = ipm::get_recommended_plugin_name(
+    is_topic(connection_or_topic) || is_pubsub_connection(connection_or_topic) ? ipm::IpmPluginType::Subscriber
+                                                                               : ipm::IpmPluginType::Receiver);
 
   TLOG_DEBUG(12) << "Creating plugin for connection or topic " << connection_or_topic << " of type " << plugin_type;
   m_receiver_plugins[connection_or_topic] = dunedaq::ipm::make_ipm_receiver(plugin_type);

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -368,6 +368,14 @@ NetworkManager::create_receiver(std::string const& connection_or_topic)
       subscriber->subscribe(connection_or_topic);
     }
 
+    if (is_pubsub_connection(connection_or_topic)) {
+      TLOG_DEBUG(12) << "Subscribing to topics on " << connection_or_topic << " after connect_for_receives";
+      auto subscriber = std::dynamic_pointer_cast<ipm::Subscriber>(m_receiver_plugins[connection_or_topic]);
+      for (auto& topic : m_connection_map[connection_or_topic].topics) {
+        subscriber->subscribe(topic);
+      }
+    }
+
   } catch (ers::Issue const&) {
     m_receiver_plugins.erase(connection_or_topic);
     throw;

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -90,9 +90,9 @@ NetworkManager::start_listening(std::string const& connection_name)
     throw ConnectionNotFound(ERS_HERE, connection_name);
   }
 
-  if (is_pubsub_connection(connection_name)) {
+  /* if (is_pubsub_connection(connection_name)) {
     throw OperationFailed(ERS_HERE, "Connection is pub/sub type, call start_listening on desired topic(s) instead!");
-  }
+  }*/
 
   if (is_listening(connection_name)) {
     throw ListenerAlreadyRegistered(ERS_HERE, connection_name);
@@ -123,9 +123,9 @@ NetworkManager::register_callback(std::string const& connection_or_topic,
     throw ConnectionNotFound(ERS_HERE, connection_or_topic);
   }
 
-  if (is_pubsub_connection(connection_or_topic)) {
+  /* if (is_pubsub_connection(connection_or_topic)) {
     throw OperationFailed(ERS_HERE, "Connection is pub/sub type, call register_callback on desired topic(s) instead!");
-  }
+  }*/
 
   if (!is_listening(connection_or_topic)) {
     throw ListenerNotRegistered(ERS_HERE, connection_or_topic);


### PR DESCRIPTION
While working on the conversion of the receipt of TimeSync messages in the DQMProcessor to use the NetworkManager, Eric realized that we needed a slight modification to the NetworkManager itself to allow us to subscribe to a subset of the publishers of TimeSync messages.

This branch has those changes.