### PR TITLE
JCF: fix typo in nwmgrinfo.jsonnet where incorrect namespace (network…

### DIFF
--- a/schema/networkmanager/nwmgrinfo.jsonnet
+++ b/schema/networkmanager/nwmgrinfo.jsonnet
@@ -3,7 +3,7 @@
 // for operational monitoring
 
 local moo = import "moo.jsonnet";
-local s = moo.oschema.schema("dunedaq.networkmanager.networkmanagerinfo");
+local s = moo.oschema.schema("dunedaq.networkmanager.nwmgrinfo");
 
 local info = {
 


### PR DESCRIPTION
…managerinfo instead of nwmgrinfo) was being used