### PR TITLE
Eflumerf/protect listener callback

### DIFF
--- a/include/networkmanager/Listener.hpp
+++ b/include/networkmanager/Listener.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/include/networkmanager/Listener.hpp
+++ b/include/networkmanager/Listener.hpp
@@ -51,6 +51,7 @@ private:
 
   std::string m_connection_name = "";
   std::function<void(ipm::Receiver::Response)> m_callback;
+  mutable std::mutex m_callback_mutex;
   std::unique_ptr<std::thread> m_listener_thread{ nullptr };
   std::atomic<bool> m_is_listening{ false };
 };

--- a/include/networkmanager/NetworkManager.hpp
+++ b/include/networkmanager/NetworkManager.hpp
@@ -44,7 +44,6 @@ public:
 
   static NetworkManager& get();
 
-
   void gather_stats(opmonlib::InfoCollector& ci, int /*level*/);
   void configure(const nwmgr::Connections& connections);
   void reset();

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -14,6 +14,7 @@
 #include "ipm/Subscriber.hpp"
 #include "logging/Logging.hpp"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -120,10 +121,6 @@ NetworkManager::start_listening(std::string const& connection_name)
     throw ConnectionNotFound(ERS_HERE, connection_name);
   }
 
-  /* if (is_pubsub_connection(connection_name)) {
-    throw OperationFailed(ERS_HERE, "Connection is pub/sub type, call start_listening on desired topic(s) instead!");
-  }*/
-
   if (is_listening_locked(connection_name)) {
     throw ListenerAlreadyRegistered(ERS_HERE, connection_name);
   }
@@ -152,10 +149,6 @@ NetworkManager::register_callback(std::string const& connection_or_topic,
   if (!m_connection_map.count(connection_or_topic) && !m_topic_map.count(connection_or_topic)) {
     throw ConnectionNotFound(ERS_HERE, connection_or_topic);
   }
-
-  /* if (is_pubsub_connection(connection_or_topic)) {
-    throw OperationFailed(ERS_HERE, "Connection is pub/sub type, call register_callback on desired topic(s) instead!");
-  }*/
 
   if (!is_listening_locked(connection_or_topic)) {
     throw ListenerNotRegistered(ERS_HERE, connection_or_topic);

--- a/unittest/NetworkManager_test.cxx
+++ b/unittest/NetworkManager_test.cxx
@@ -382,13 +382,15 @@ BOOST_FIXTURE_TEST_CASE(Publish, NetworkManagerTestFixture)
   BOOST_REQUIRE_EQUAL(received_string, "");
 }
 
-BOOST_FIXTURE_TEST_CASE(SingleConnectionSubscriber, NetworkManagerTestFixture) {
+BOOST_FIXTURE_TEST_CASE(SingleConnectionSubscriber, NetworkManagerTestFixture)
+{
 
   std::string sent_string;
   std::string received_string_topic;
   std::string received_string_conn;
 
-  std::function<void(dunedaq::ipm::Receiver::Response)> callback_topic = [&](dunedaq::ipm::Receiver::Response response) {
+  std::function<void(dunedaq::ipm::Receiver::Response)> callback_topic =
+    [&](dunedaq::ipm::Receiver::Response response) {
       received_string_topic = std::string(response.data.begin(), response.data.end());
     };
   NetworkManager::get().subscribe("baz");


### PR DESCRIPTION
Resolves an issue that can occur if the Listener is shutdown (stop_listening or clear_callback called) while in the middle of processing a received message.