### PR TITLE
Add typed send_to and receive_from methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(opmonlib REQUIRED)
 find_package(ers REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(serialization REQUIRED)
 
 ##############################################################################
 # Schema
@@ -25,7 +26,7 @@ daq_codegen( connectioninfo.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStr
 ##############################################################################
 # Main library
 
-daq_add_library(NetworkManager.cpp Listener.cpp LINK_LIBRARIES ipm::ipm utilities::utilities logging::logging opmonlib::opmonlib)
+daq_add_library(NetworkManager.cpp Listener.cpp LINK_LIBRARIES ipm::ipm utilities::utilities logging::logging opmonlib::opmonlib serialization::serialization)
 
 ##############################################################################
 # Unit tests

--- a/cmake/networkmanagerConfig.cmake.in
+++ b/cmake/networkmanagerConfig.cmake.in
@@ -9,6 +9,7 @@ find_dependency(opmonlib)
 find_dependency(utilities)
 find_dependency(ers)
 find_dependency(nlohmann_json)
+find_dependency(serialization)
 
 # Figure out whether or not this dependency is an installed package or
 # in repo form

--- a/include/networkmanager/NetworkManager.hpp
+++ b/include/networkmanager/NetworkManager.hpp
@@ -17,6 +17,7 @@
 #include "ipm/Receiver.hpp"
 #include "ipm/Sender.hpp"
 #include "opmonlib/InfoCollector.hpp"
+#include "serialization/Serialization.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -64,6 +65,23 @@ public:
                ipm::Sender::duration_t timeout,
                std::string const& topic = "");
   ipm::Receiver::Response receive_from(std::string const& connection_or_topic, ipm::Receiver::duration_t timeout);
+
+  template<typename T>
+  T const& receive_from(std::string const& connection_or_topic, ipm::Receiver::duration_t timeout)
+  {
+    auto response = receive_from(connection_or_topic, timeout);
+    auto object = dunedaq::serialization::deserialize<T>(response.data());
+    return object;
+  }
+  template<typename T>
+  void send_to(std::string connection_name,
+      T const& object,
+      ipm::Sender::duration_t timeout,
+      std::string const& topic = "")
+  {
+    auto message = dunedaq::serialization::serialize(object, dunedaq::serialization::SerializationType::kMsgPack);
+    send_to(connection_name, message.data(), message.size(), timeout, topic);
+  }
 
   std::string get_connection_string(std::string const& connection_name) const;
   std::vector<std::string> get_connection_strings(std::string const& topic) const;


### PR DESCRIPTION
These handle serialization/deserialization on behalf of the user.

Can still be useful in `feature/iomanager`, as it reduces `read_network` and `write_network` to a single line.